### PR TITLE
Fixed invalid link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ plugins:
 
 ### In supported themes
 
-- [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) offers support for this plugin, see [setup instructions](https://squidfunk.github.io/mkdocs-material/extensions/revision_date/)
+- [mkdocs-material](https://squidfunk.github.io/mkdocs-material/) offers support for this plugin, see [setup instructions](https://squidfunk.github.io/mkdocs-material/extensions/revision-date/)
 
 ### In theme templates
 


### PR DESCRIPTION
I changed the filename to kebap-case, so the link is no longer valid. This PR fixes that.