### PR TITLE
Use `var` for compatibility

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -77,8 +77,8 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
           <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.0-beta.2/timeago.min.js"></script>
           <script src="https://cdnjs.cloudflare.com/ajax/libs/timeago.js/4.0.0-beta.2/timeago.locales.min.js"></script>
           <script>
-            const nodes = document.querySelectorAll('.timeago');
-            const locale = nodes[0].getAttribute('locale');
+            var nodes = document.querySelectorAll('.timeago');
+            var locale = nodes[0].getAttribute('locale');
             timeago.render(nodes, locale);
           </script>
         """


### PR DESCRIPTION
Var is more supported, and it doesn’t hurt to have the support. 