### PR TITLE
Use time.time() to obtain unix timestamp

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -1,6 +1,7 @@
 # standard library
 import logging
 import os
+import time
 from datetime import datetime
 
 # 3rd party
@@ -116,7 +117,7 @@ class Util:
 
         # create timestamp
         if not unix_timestamp:
-            unix_timestamp = datetime.utcnow().timestamp()
+            unix_timestamp = time.time()
             logging.warning("%s has no git logs, using current timestamp" % path)
 
         return self._date_formats(unix_timestamp=unix_timestamp, locale=locale)


### PR DESCRIPTION
datetime.utcnow() returns an instance with no timezone information, and calling timestamp() on it applies a local to UTC conversion again. time.time() returns a unix timestamp directly, so there's no need to deal with UTC or timezone offsets.