### PR TITLE
Add configuration for git path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Specify a two letter [ISO639](https://en.wikipedia.org/wiki/List_of_ISO_639-1_co
 
 If set to `true` (default is `false`) the plugin will use the time when running `mkdocs build` instead of the git revision date. This means the revision date will be inaccurate, but this can be useful if your build environment has no access to GIT and you want to ignore the Git exceptions during `git log`.
 
+### `git_path`
+
+Specify a path to the folder that is a git repository (the folder that contains `.git`). If not specified, default path is `.`.
+
 ----
 
 ### Example
@@ -104,6 +108,7 @@ plugins:
     locale: en
     type: timeago
     fallback_to_build_date: true
+    git_path: ./docs
 ```
 
 Result:

--- a/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -16,10 +16,11 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
         ("fallback_to_build_date", config_options.Type(bool, default=False)),
         ("locale", config_options.Type(str, default=None)),
         ("type", config_options.Type(str, default="date")),
+        ("git_path", config_options.Type(str, default=".")),
     )
 
     def __init__(self):
-        self.util = Util()
+        pass
 
     def on_config(self, config: config_options.Config) -> dict:
         """
@@ -36,6 +37,8 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
         Returns:
             dict: global configuration object
         """
+
+        self.util = Util(path=self.config.get("git_path", "."))
 
         # Get locale settings - might be added in future mkdocs versions
         # see: https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/issues/24

--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -10,7 +10,7 @@ from git import Git, GitCommandError, GitCommandNotFound
 
 
 class Util:
-    def __init__(self, path: str = "."):
+    def __init__(self, path: str = "./docs"):
         self.repo = Git(path)
 
         # Checks when running builds on CI

--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -10,7 +10,7 @@ from git import Git, GitCommandError, GitCommandNotFound
 
 
 class Util:
-    def __init__(self, path: str = "./docs"):
+    def __init__(self, path: str = "."):
         self.repo = Git(path)
 
         # Checks when running builds on CI


### PR DESCRIPTION
We've added a config `git_path` that can be used to specify the folder that contains the git repository. If this configuration is not set, the default will be `.`, which was the previous behavior
We've added this because our git repository info is inside a `docs` folder, different from the mkdocs default structure, and that configuration would help for situations like that