### PR TITLE
Add {{git_creation_date_localized}}

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ plugins:
       timezone: Europe/Amsterdam
       locale: en
       fallback_to_build_date: false
+      enable_creation_date: true
       exclude:
         - index.md
 ```
@@ -151,6 +152,10 @@ Default is `None`. Specify a two letter [ISO639](https://en.wikipedia.org/wiki/L
 ### `fallback_to_build_date`
 
 Default is `false`. If set to `true` the plugin will use the time at `mkdocs build` instead of the file's last git revision date *when git is not available*. This means the revision date can be incorrect, but this can be acceptable if you want your project to also successfully build in environments with no access to GIT.
+
+### `enable_creation_date`
+
+Default is `false`. If set to `true`, you will be able to use `{{git_creation_date_localized}}` in markdown files and `page.meta.git_creation_date_localized` in page templates.
 
 ### `exclude`
 

--- a/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -148,14 +148,13 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
             logging.debug("Excluding page " + page.file.src_path)
             return markdown
 
-        commit_timestamp_list = self.util.get_git_commit_timestamps(
-            path=page.file.abs_src_path,
-            fallback_to_build_date=self.config.get("fallback_to_build_date"),
-        )
-
         # revision date
         revision_dates = self.util.get_revision_date_for_file(
-            commit_timestamp_list=commit_timestamp_list,
+            commit_timestamp=self.util.get_git_commit_timestamp(
+                path=page.file.abs_src_path,
+                is_first_commit=False,
+                fallback_to_build_date=self.config.get("fallback_to_build_date"),
+            ),
             locale=self.config.get("locale", "en"),
             time_zone=self.config.get("time_zone", "UTC"),
         )
@@ -175,11 +174,14 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
             flags=re.IGNORECASE,
         )
 
-        # todo don't get full log when not enabled
         # Creation date
         if self.config.get("enable_creation_date"):
             creation_dates = self.util.get_creation_date_for_file(
-                commit_timestamp_list=commit_timestamp_list,
+                commit_timestamp=self.util.get_git_commit_timestamp(
+                    path=page.file.abs_src_path,
+                    is_first_commit=True,
+                    fallback_to_build_date=self.config.get("fallback_to_build_date"),
+                ),
                 locale=self.config.get("locale", "en"),
                 time_zone=self.config.get("time_zone", "UTC"),
             )

--- a/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -37,6 +37,7 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
         ("type", config_options.Type(str, default="date")),
         ("timezone", config_options.Type(str, default="UTC")),
         ("exclude", config_options.Type(list, default=[])),
+        ("enable_creation_date", config_options.Type(bool, default=False)),
     )
 
     def on_config(self, config: config_options.Config, **kwargs) -> Dict[str, Any]:
@@ -174,6 +175,7 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
             flags=re.IGNORECASE,
         )
 
+        # todo don't get full log when not enabled
         # Creation date
         if self.config.get("enable_creation_date"):
             creation_dates = self.util.get_creation_date_for_file(

--- a/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -175,23 +175,26 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
         )
 
         # Creation date
-        creation_dates = self.util.get_creation_date_for_file(
-            commit_timestamp_list=commit_timestamp_list,
-            locale=self.config.get("locale", "en"),
-            time_zone=self.config.get("time_zone", "UTC"),
-        )
-        creation_date = creation_dates[self.config["type"]]
+        if self.config.get("enable_creation_date"):
+            creation_dates = self.util.get_creation_date_for_file(
+                commit_timestamp_list=commit_timestamp_list,
+                locale=self.config.get("locale", "en"),
+                time_zone=self.config.get("time_zone", "UTC"),
+            )
+            creation_date = creation_dates[self.config["type"]]
 
-        if self.config["type"] == "timeago":
-            creation_date += creation_dates["iso_date"]
+            if self.config["type"] == "timeago":
+                creation_date += creation_dates["iso_date"]
 
-        page.meta["git_creation_date_localized"] = creation_date
-        return re.sub(
-            r"\{\{\s*[page\.meta\.]*git_creation_date_localized\s*\}\}",
-            creation_date,
-            markdown,
-            flags=re.IGNORECASE,
-        )
+            page.meta["git_creation_date_localized"] = creation_date
+            markdown = re.sub(
+                r"\{\{\s*[page\.meta\.]*git_creation_date_localized\s*\}\}",
+                creation_date,
+                markdown,
+                flags=re.IGNORECASE,
+            )
+
+        return markdown
 
     def on_post_build(self, config: Dict[str, Any], **kwargs) -> None:
         """

--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -16,7 +16,7 @@ from git import (
     NoSuchPathError,
 )
 
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 logger = logging.getLogger("mkdocs.plugins")
 

--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -9,13 +9,14 @@ from mkdocs_git_revision_date_localized_plugin.ci import raise_ci_warnings
 from babel.dates import format_date, get_timezone
 from git import (
     Repo,
+    Git,
     GitCommandError,
     GitCommandNotFound,
     InvalidGitRepositoryError,
     NoSuchPathError,
 )
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 logger = logging.getLogger("mkdocs.plugins")
 
@@ -32,7 +33,7 @@ class Util:
         self.config = config
         self.repo_cache = {}
 
-    def _get_repo(self, path: str):
+    def _get_repo(self, path: str) -> Git:
         if not os.path.isdir(path):
             path = os.path.dirname(path)
 
@@ -78,25 +79,22 @@ class Util:
             % (loc_revision_date.isoformat(), locale),
         }
 
-    def get_revision_date_for_file(
-        self,
-        path: str,
-        locale: str = "en",
-        time_zone: str = "UTC",
-        fallback_to_build_date: bool = False,
-    ) -> Dict[str, str]:
+    def get_git_commit_timestamps(
+            self,
+            path: str,
+            fallback_to_build_date: bool = False,
+    ) -> List[int]:
         """
-        Determine localized date variants for a given file.
+        Get a list of commit dates in unix timestamp, starts with the most recent commit.
 
         Args:
             path (str): Location of a markdown file that is part of a Git repository.
-            locale (str, optional): Locale code of language to use. Defaults to 'en'.
-            timezone (str): Timezone database name (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
         Returns:
-            dict: Localized date variants.
+            list: commit dates in unix timestamp, starts with the most recent commit.
         """
-        unix_timestamp = None
+
+        commit_timestamp_list = []
 
         # perform git log operation
         try:
@@ -104,9 +102,10 @@ class Util:
                 # Retrieve author date in UNIX format (%at)
                 # https://git-scm.com/docs/git-log#Documentation/git-log.txt-ematem
                 realpath = os.path.realpath(path)
-                unix_timestamp = self._get_repo(realpath).log(
-                    realpath, n=1, date="short", format="%at"
-                )
+                commit_timestamp_list = self._get_repo(realpath).log(
+                    realpath, date="short", format="%at"
+                ).split()
+                commit_timestamp_list = list(map(int, commit_timestamp_list))
         except (InvalidGitRepositoryError, NoSuchPathError) as err:
             if fallback_to_build_date:
                 logger.warning(
@@ -147,16 +146,36 @@ class Util:
                 raise err
 
         # create timestamp
-        if not unix_timestamp:
-            unix_timestamp = time.time()
+        if not len(commit_timestamp_list):
+            commit_timestamp_list = [int(time.time())]
             if not self.fallback_enabled:
                 logger.warning(
                     "[git-revision-date-localized-plugin] '%s' has no git logs, using current timestamp"
                     % path
                 )
 
+        return commit_timestamp_list
+
+    def get_revision_date_for_file(
+        self,
+        commit_timestamp_list: List,
+        locale: str = "en",
+        time_zone: str = "UTC",
+    ) -> Dict[str, str]:
+        """
+        Determine localized date variants for a given file.
+
+        Args:
+            commit_timestamp_list (List): List of commit dates in unix timestamp, starts with the most recent commit.
+            locale (str, optional): Locale code of language to use. Defaults to 'en'.
+            time_zone (str): Timezone database name (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+        Returns:
+            dict: Localized date variants.
+        """
+
         date_formats = self._date_formats(
-            unix_timestamp=unix_timestamp, time_zone=time_zone, locale=locale
+            unix_timestamp=commit_timestamp_list[0], time_zone=time_zone, locale=locale
         )
 
         # Wrap in <span> for styling
@@ -164,6 +183,37 @@ class Util:
             date_formats[date_type] = (
                 '<span class="git-revision-date-localized-plugin git-revision-date-localized-plugin-%s">%s</span>'
                 % (date_type, date_string)
+            )
+
+        return date_formats
+
+    def get_creation_date_for_file(
+            self,
+            commit_timestamp_list: List,
+            locale: str = "en",
+            time_zone: str = "UTC",
+    ) -> Dict[str, str]:
+        """
+        Determine localized date variants for a given file.
+
+        Args:
+            commit_timestamp_list (List): List of commit dates in unix timestamp, starts with the most recent commit.
+            locale (str, optional): Locale code of language to use. Defaults to 'en'.
+            time_zone (str): Timezone database name (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+        Returns:
+            dict: Localized date variants.
+        """
+
+        date_formats = self._date_formats(
+            unix_timestamp=commit_timestamp_list[-1], time_zone=time_zone, locale=locale
+        )
+
+        # Wrap in <span> for styling
+        for date_type, date_string in date_formats.items():
+            date_formats[date_type] = (
+                    '<span class="git-revision-date-localized-plugin git-revision-date-localized-plugin-%s">%s</span>'
+                    % (date_type, date_string)
             )
 
         return date_formats

--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -97,7 +97,7 @@ class Util:
             list: commit dates in unix timestamp, starts with the most recent commit.
         """
 
-        commit_timestamp = None
+        commit_timestamp = ""
 
         # perform git log operation
         try:
@@ -107,13 +107,13 @@ class Util:
                 realpath = os.path.realpath(path)
                 git = self._get_repo(realpath)
                 if is_first_commit:
-                    commit_timestamp = int(git.log(
+                    commit_timestamp = git.log(
                         realpath, date="short", format="%at", diff_filter="A"
-                    ))
+                    )
                 else:
-                    commit_timestamp = int(git.log(
+                    commit_timestamp = git.log(
                         realpath, date="short", format="%at", n=1
-                    ))
+                    )
         except (InvalidGitRepositoryError, NoSuchPathError) as err:
             if fallback_to_build_date:
                 logger.warning(
@@ -154,15 +154,15 @@ class Util:
                 raise err
 
         # create timestamp
-        if commit_timestamp is None:
-            commit_timestamp = int(time.time())
+        if commit_timestamp == "":
+            commit_timestamp = time.time()
             if not self.fallback_enabled:
                 logger.warning(
                     "[git-revision-date-localized-plugin] '%s' has no git logs, using current timestamp"
                     % path
                 )
 
-        return commit_timestamp
+        return int(commit_timestamp)
 
     def get_revision_date_for_file(
         self,

--- a/tests/fixtures/basic_project/docs/page_with_tag.md
+++ b/tests/fixtures/basic_project/docs/page_with_tag.md
@@ -1,3 +1,5 @@
 # test page
 
 Tag <mark>\{\{ git_revision_date_localized \}\}</mark> renders as: {{ git_revision_date_localized }}
+
+Tag <mark>\{\{ git_creation_date_localized \}\}</mark> renders as: {{ git_creation_date_localized }}

--- a/tests/fixtures/basic_project/mkdocs_creation_date.yml
+++ b/tests/fixtures/basic_project/mkdocs_creation_date.yml
@@ -1,0 +1,7 @@
+site_name: test gitrevisiondatelocalized_plugin
+use_directory_urls: true
+
+plugins:
+    - search
+    - git-revision-date-localized:
+        enable_creation_date: True

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -195,9 +195,12 @@ def validate_build(testproject_path, plugin_config: dict = {}):
 
     repo = Util(str(testproject_path / "docs"))
     date_formats = repo.get_revision_date_for_file(
-        path=str(testproject_path / "docs/page_with_tag.md"),
+        commit_timestamp=repo.get_git_commit_timestamp(
+            path=str(testproject_path / "docs/page_with_tag.md"),
+            is_first_commit=False,
+            fallback_to_build_date=plugin_config.get("fallback_to_build_date"),
+        ),
         locale=plugin_config.get("locale"),  # type: ignore
-        fallback_to_build_date=plugin_config.get("fallback_to_build_date"),  # type: ignore
     )
 
     searches = [x in contents for x in date_formats.values()]


### PR DESCRIPTION
relating issue: #49

This pr adds `{{git_creation_date_localized}}`

I improved performance of getting the creation date by using `git.log(realpath, date="short", format="%at", diff_filter="A")`. The reverse option mentioned in the issue doesn't work because it reverse the output *after* limiting the lines.