### PR TITLE
Fix bug in getting creation date commit when multiple creations

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -109,6 +109,10 @@ class Util:
                 commit_timestamp = git.log(
                     realpath, date="short", format="%at", diff_filter="A"
                 )
+                # A file can be created multiple times, through a file renamed. 
+                # Commits are ordered with most recent commit first
+                # Get the oldest commit only
+                commit_timestamp = commit_timestamp.split()[-1]
             else:
                 commit_timestamp = git.log(
                     realpath, date="short", format="%at", n=1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ del file
 
 setup(
     name="mkdocs-git-revision-date-localized-plugin",
-    version="0.9",
+    version="0.9.1",
     description="Mkdocs plugin that enables displaying the localized date of the last git modification of a markdown file.",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
When you rename a file, that's also counted as creation.