### PR TITLE
Set fixed dependency version for GitPython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs>=1.0
-GitPython
+GitPython==3.1.19
 babel>=2.7.0


### PR DESCRIPTION
Hey,

We've had an issue in our pipeline lately that appears to have been due to a combination of Python 3.7 on the build box and this plugin transitively pulling GitPython v3.1.20. The issue appears to be related to https://github.com/gitpython-developers/GitPython/issues/1095. We were able to resolve the issue by setting the last known working version, which was 3.1.19. It's now fixed for us since we added GitPython to our own project dependencies with that version, but this might help others avoid the issue altogether. Otherwise some sort of FAQ or troubleshooting/setup guide might be helpful where people should set their own reliable version for stable builds.

Cheers!