### PR TITLE
Update broken link for GitLab Runner settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This plugin needs access to the last commit that touched a specific file to be a
   <summary>Change your CI settings</summary>
     <ul>
       <li>github actions: set <code>fetch-depth</code> to <code>0</code> (<a href="https://github.com/actions/checkout">docs</a>)</li>
-      <li>gitlab runners: set <code>GIT_DEPTH</code> to <code>0</code> (<a href="https://docs.gitlab.com/ee/user/project/pipelines/settings.html#git-shallow-clone">docs</a>)</li>
+      <li>gitlab runners: set <code>GIT_DEPTH</code> to <code>0</code> (<a href="https://docs.gitlab.com/ee/ci/pipelines/settings.html#limit-the-number-of-changes-fetched-during-clone">docs</a>)</li>
       <li>bitbucket pipelines: set <code>clone: depth: full</code> (<a href="https://support.atlassian.com/bitbucket-cloud/docs/configure-bitbucket-pipelinesyml/">docs</a>)</li>
     </ul>
 </details>


### PR DESCRIPTION
Updates a broken link in the README relating to the `GIT_DEPTH` variable for GitLab Runners.

Closes #71 