### PR TITLE
Hide signature information when getting git log

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -112,7 +112,7 @@ class Util:
             if is_first_commit:
                 # diff_filter="A" will select the commit that created the file
                 commit_timestamp = git.log(
-                    realpath, date="unix", format="%at", diff_filter="A"
+                    realpath, date="unix", format="%at", diff_filter="A", no_show_signature=True
                 )
                 # A file can be created multiple times, through a file renamed. 
                 # Commits are ordered with most recent commit first
@@ -122,7 +122,7 @@ class Util:
             else:
                 # Latest commit touching a specific file
                 commit_timestamp = git.log(
-                    realpath, date="unix", format="%at", n=1
+                    realpath, date="unix", format="%at", n=1, no_show_signature=True
                 )
         except (InvalidGitRepositoryError, NoSuchPathError) as err:
             if self.config.get('fallback_to_build_date'):


### PR DESCRIPTION
Fixes #87 

I'm not sure why but I am getting some failing test:

>tests/test_builds.py:607
>E       AttributeError: 'IterableList' object has no attribute 'origin/master'

This might be okay though.