### PR TITLE
Add ignored commits feature

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -17,6 +17,7 @@ You can customize the plugin by setting options in `mkdocs.yml`. For example:
             - index.md
         enabled: true
         strict: true
+        ignored_commits_file: .git-blame-ignore-revs
   ```
 
 ## `type`
@@ -146,4 +147,19 @@ Default is `true`. When enabled, the logs will show warnings when something is w
   plugins:
     - git-revision-date-localized:
         strict: true
+  ```
+
+## `ignored_commits_file`
+
+Default is `None`. When specified, contains a file that contains a list of commit hashes to ignore
+when determining the most recent updated time. The format of the file is the same as the format of
+git `blame.ignoreRevsFile`. This can be useful to ignore formatting updates or other mass changes to the documents.
+
+
+=== ":octicons-file-code-16: mkdocs.yml"
+
+  ```yaml
+  plugins:
+    - git-revision-date-localized:
+        ignored_commits_file: .git-blame-ignore-revs
   ```

--- a/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -44,6 +44,7 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
         ("enable_creation_date", config_options.Type(bool, default=False)),
         ("enabled", config_options.Type(bool, default=True)),
         ("strict", config_options.Type(bool, default=True)),
+        ("ignored_commits_file", config_options.Type(str, default=None)),
     )
 
     def on_config(self, config: config_options.Config, **kwargs) -> Dict[str, Any]:

--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -16,7 +16,7 @@ from git import (
     NoSuchPathError,
 )
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 logger = logging.getLogger("mkdocs.plugins")
 
@@ -31,6 +31,9 @@ class Util:
         """Initialize utility class."""
         self.config = config
         self.repo_cache = {}
+
+        ignore_commits_file = self.config.get("ignored_commits_file")
+        self.ignored_commits = self.parse_git_ignore_revs(ignore_commits_file) if ignore_commits_file else []
 
     def _get_repo(self, path: str) -> Git:
         if not os.path.isdir(path):
@@ -117,6 +120,7 @@ class Util:
             realpath = os.path.realpath(path)
             git = self._get_repo(realpath)
 
+            # Ignored commits are only considered for the most recent update, not for creation
             if is_first_commit:
                 # diff_filter="A" will select the commit that created the file
                 commit_timestamp = git.log(
@@ -128,10 +132,21 @@ class Util:
                 if commit_timestamp != "":
                     commit_timestamp = commit_timestamp.split()[-1]
             else:
-                # Latest commit touching a specific file
-                commit_timestamp = git.log(
-                    realpath, date="unix", format="%at", n=1, no_show_signature=True
-                )
+                # Retrieve the history for the file in the format <hash> <timestamp>
+                # The maximum number of commits we will ever need to examine is 1 more than the number of ignored commits.
+                lines = git.log(
+                        realpath, date="unix", format="%H %at", n=len(self.ignored_commits)+1, no_show_signature=True,
+                ).split("\n")
+                # process the commits for the file in reverse-chronological order. Ignore any commit that is on the
+                # ignored list. If the line is empty, we've reached the end and need to use the fallback behavior
+                for line in lines:
+                    if not line:
+                        commit_timestamp = ""
+                        break
+                    commit, commit_timestamp = line.split(" ")
+                    if not any(commit.startswith(x) for x in self.ignored_commits):
+                        break
+
         except (InvalidGitRepositoryError, NoSuchPathError) as err:
             if self.config.get('fallback_to_build_date'):
                 log(
@@ -224,3 +239,19 @@ class Util:
                 % (date_type, date_string)
             )
         return date_formats
+
+    @staticmethod
+    def parse_git_ignore_revs(filename: str) -> List[str]:
+        """
+        Parses a file that is the same format as git's blame.ignoreRevsFile and return the list of commit hashes.
+
+        Whitespace, blanklines and comments starting with # are all ignored.
+        """
+        result = []
+        with open(filename, "rt") as f:
+            for line in f:
+                line = line.split("#", 1)[0].strip()
+                if not line:
+                    continue
+                result.append(line)
+        return result

--- a/tests/fixtures/basic_project/mkdocs_ignored_commits.yml
+++ b/tests/fixtures/basic_project/mkdocs_ignored_commits.yml
@@ -1,0 +1,8 @@
+site_name: test gitrevisiondatelocalized_plugin
+use_directory_urls: true
+
+plugins:
+    - search
+    - git-revision-date-localized:
+        enable_creation_date: True
+        ignored_commits_file: ignored-commits.txt

--- a/tests/test_parse_git_ignore_revs.py
+++ b/tests/test_parse_git_ignore_revs.py
@@ -1,0 +1,16 @@
+from mkdocs_git_revision_date_localized_plugin.util import Util
+import pytest
+import tempfile
+
+TEST_PARAMS = [
+    (b"abc123\n", ["abc123"]),
+    (b"abc123 # comments are ignored\n", ["abc123"]),
+    (b"\n\n\n\n\nabc123\n\n\n\n\n", ["abc123"]),
+]
+
+@pytest.mark.parametrize("test_input,expected", TEST_PARAMS)
+def test_parse_git_ignore_revs(test_input, expected):
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(test_input)
+        fp.flush()
+        assert Util.parse_git_ignore_revs(fp.name) == expected


### PR DESCRIPTION
This addresses #113 by adding a new option "ignored_commits_file" that points to a file to contain commit hashes in the same format as `blame.ignoreRevsFile` that will be ignored during calculation of the most recent update. To the best of my knowledge, it is not possible to ask `git log` to ignore commits, so this must be done by the plugin.

I've added a basic unit test for the file parser, and an integration test to validate the commit ignoring behavior.

I've tested this on my own repository and verified that it behaves as expected.

pyflakes shows no new issues. pytest shows no changed lines without coverage.