### PR TITLE
[fix] get locale for mkdocs-static-i18n

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -176,7 +176,7 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
 
         # First prio is use mkdocs-static-i18n locale if set
         try:
-            locale = page.locale
+            locale = page.file.locale
 
         except AttributeError:
             locale = None


### PR DESCRIPTION
Faced a problem, the date was not translating. 
The property is taken from the wrong object

https://github.com/ultrabug/mkdocs-static-i18n/blob/5f97ac28b9f67a3db0f196edf2a1a0059b718213/mkdocs_static_i18n/plugin.py#L138
https://github.com/ultrabug/mkdocs-static-i18n/blob/5f97ac28b9f67a3db0f196edf2a1a0059b718213/mkdocs_static_i18n/suffix.py#L92C1-L92C1
https://github.com/ultrabug/mkdocs-static-i18n/blob/5f97ac28b9f67a3db0f196edf2a1a0059b718213/mkdocs_static_i18n/folder.py#L87C1-L87C1
