### PR TITLE
For jinja autoescape, mark HTML strings as safe, not needing escaping

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -3,6 +3,8 @@ import logging
 import os
 import time
 
+from markupsafe import Markup
+
 from mkdocs_git_revision_date_localized_plugin.ci import raise_ci_warnings
 from mkdocs_git_revision_date_localized_plugin.dates import get_date_formats
 
@@ -85,7 +87,7 @@ class Util:
                 commit_timestamp = git.log(
                     realpath, date="unix", format="%at", diff_filter="A", no_show_signature=True, follow=True
                 )
-                # A file can be created multiple times, through a file renamed. 
+                # A file can be created multiple times, through a file renamed.
                 # Commits are ordered with most recent commit first
                 # Get the oldest commit only
                 if commit_timestamp != "":
@@ -165,7 +167,7 @@ class Util:
             dict: Localized date variants.
         """
         date_formats = get_date_formats(
-            unix_timestamp=commit_timestamp, 
+            unix_timestamp=commit_timestamp,
             time_zone=self.config.get("timezone"),
             locale=locale,
             custom_format=self.config.get('custom_format')
@@ -183,7 +185,7 @@ class Util:
         """
         for date_type, date_string in date_formats.items():
             date_formats[date_type] = (
-                '<span class="git-revision-date-localized-plugin git-revision-date-localized-plugin-%s">%s</span>'
+                Markup('<span class="git-revision-date-localized-plugin git-revision-date-localized-plugin-%s">%s</span>')
                 % (date_type, date_string)
             )
         return date_formats

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs>=1.0
 GitPython
 babel>=2.7.0
 pytz
+markupsafe


### PR DESCRIPTION
For contexts where Jinja's autoescape is enabled, this is necessary for keeping this string working without it being escaped.
(This might become the default behavior in the next version of MkDocs)

If so, without this change, the HTML will be pasted like this into the doc:

    &lt;span class=&#34;git-revision-date-localized-plugin git-revision-date-localized-plugin-date&#34;&gt;March 17, 2022&lt;/span&gt;

When Jinja's autoescape is not enabled, there's no change in behavior.
