### PR TITLE
Reland: For jinja autoescape, mark HTML strings as safe, not needing escaping

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/mkdocs_git_revision_date_localized_plugin/util.py
@@ -3,6 +3,8 @@ import logging
 import os
 import time
 
+from markupsafe import Markup
+
 from mkdocs_git_revision_date_localized_plugin.ci import raise_ci_warnings
 from mkdocs_git_revision_date_localized_plugin.dates import get_date_formats
 
@@ -182,7 +184,7 @@ class Util:
         Wraps the date string in <span> elements with CSS identifiers.
         """
         for date_type, date_string in date_formats.items():
-            date_formats[date_type] = (
+            date_formats[date_type] = Markup(
                 '<span class="git-revision-date-localized-plugin git-revision-date-localized-plugin-%s">%s</span>'
                 % (date_type, date_string)
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs>=1.0
 GitPython
 babel>=2.7.0
 pytz
+markupsafe


### PR DESCRIPTION
**(The previous version of this change had a mistake that was inserting Markup in the wrong place.)**

* https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/pull/126#discussion_r1477012765

---

Original description:

For contexts where Jinja's autoescape is enabled, this is necessary for keeping this string working without it being escaped.
(This might become the default behavior in the next version of MkDocs)

If so, the HTML will be pasted like this into the doc:

    &lt;span class=&#34;git-revision-date-localized-plugin git-revision-date-localized-plugin-date&#34;&gt;March 17, 2022&lt;/span&gt;

When Jinja's autoescape is not enabled, there's no change in behavior.
