### PR TITLE
Adds use_file_dates option for non git use

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -36,6 +36,7 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
 
     config_scheme = (
         ("fallback_to_build_date", config_options.Type(bool, default=False)),
+        ("use_file_dates", config_options.Type(bool, default=False)),
         ("locale", config_options.Type(str, default=None)),
         ("type", config_options.Type(str, default="date")),
         ("custom_format", config_options.Type(str, default="%d. %B %Y")),


### PR DESCRIPTION
This PR adds a new option, use_file_dates. When set to true, this option allows the plugin to use the file creation or modification date as the timestamps instead of retrieving it from the git log.

Useful for non git projects