### PR TITLE
Fixing _vars deprecation warning

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -79,7 +79,7 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
         # theme locale
         if "theme" in config and "locale" in config.get("theme"):
             custom_theme = config.get("theme")
-            theme_locale = custom_theme._vars.get("locale")
+            theme_locale = custom_theme.locale
             logging.debug(
                 "Locale '%s' extracted from the custom theme: '%s'"
                 % (theme_locale, custom_theme.name)


### PR DESCRIPTION
With the latest mkdocs version (1.6.0), I received this deprecation warning when calling `mkdocs serve` or `mkdocs build`:

```
INFO    -  DeprecationWarning: Do not access Theme._vars, instead access the keys of Theme directly.
             File "/Users/dbermuehler/.local/share/virtualenvs/test-sX96YhBS/lib/python3.11/site-packages/mkdocs_git_revision_date_localized_plugin/plugin.py", line 82, in on_config
               theme_locale = custom_theme._vars.get("locale")
             File "/Users/dbermuehler/.local/share/virtualenvs/test-sX96YhBS/lib/python3.11/site-packages/mkdocs/theme.py", line 87, in _vars
               warnings.warn(
```

This PR will fixes this.