### PR TITLE
fixed a timeago display bug

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/js/timeago_mkdocs_material.js
+++ b/mkdocs_git_revision_date_localized_plugin/js/timeago_mkdocs_material.js
@@ -1,18 +1,33 @@
-// Script to ensure timeago keeps working when 
-// used with mkdocs-material's instant loading feature 
+// Script to ensure timeago keeps working when
+// used with mkdocs-material's instant loading feature
+
+function getLocale(element) {
+    var raw_locale = element.getAttribute('locale');
+    var locale = {
+        bn: 'bn_IN',
+        en: 'en_US',
+        hi: 'hi_IN',
+        id: 'id_ID',
+        nb: 'nb_NO',
+        nn: 'nn_NO',
+        pt: 'pt_BR',
+        zh: 'zh_CN'
+    }[raw_locale];
+    return locale ? locale : raw_locale;
+}
 
 if (typeof document$ !== "undefined") {
     document$.subscribe(function() {
         var nodes = document.querySelectorAll('.timeago');
         if (nodes.length > 0) {
-          var locale = nodes[0].getAttribute('locale');
-          timeago.render(nodes, locale);
+            var locale = getLocale(nodes[0]);
+            timeago.render(nodes, locale);
         }
     })
 } else {
     var nodes = document.querySelectorAll('.timeago');
     if (nodes.length > 0) {
-      var locale = nodes[0].getAttribute('locale');
-      timeago.render(nodes, locale);
+        var locale = getLocale(nodes[0]);
+        timeago.render(nodes, locale);
     }
 }


### PR DESCRIPTION
Fixed display bug caused by the actual locale name not exactly matching the name in the locale support list of "timeago.js".

Example: When the locale is "zh", timeago will always have the fallback version "en" as the locale.
