### PR TITLE
Fixed the bug that the configuration option `theme.language` in mkdocs.yml was not fetched correctly under the `mkdocs-material` theme

### DIFF
--- a/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -76,16 +76,16 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
         plugin_locale = self.config.get("locale", None)
 
         # theme locale
-        if "theme" in config and "locale" in config.get("theme"):
+        if "theme" in config and "language" in config.get("theme"):
             custom_theme = config.get("theme")
-            theme_locale = custom_theme.locale if Version(mkdocs_version) >= Version("1.6.0") else custom_theme._vars.get("locale")
+            theme_locale = custom_theme._vars.get("language")
             logging.debug(
                 "Locale '%s' extracted from the custom theme: '%s'"
                 % (theme_locale, custom_theme.name)
             )
-        elif "theme" in config and "language" in config.get("theme"):
+        elif "theme" in config and "locale" in config.get("theme"):
             custom_theme = config.get("theme")
-            theme_locale = custom_theme._vars.get("language")
+            theme_locale = custom_theme.locale if Version(mkdocs_version) >= Version("1.6.0") else custom_theme._vars.get("locale")
             logging.debug(
                 "Locale '%s' extracted from the custom theme: '%s'"
                 % (theme_locale, custom_theme.name)


### PR DESCRIPTION
#142 

The logic in the original code would have tried to get the configuration option called `locale` first, and then the configuration option called `language`.

But in fact, even without the `locale` option, locale still has a default value of `'en'` (I guess), which caused the code to not even get to the part where it gets the `language`, so I just **switched the order**.

This problem doesn't just occur when the type is `timeago`, but others as well.