### PR TITLE
Fixed another DeprecationWarning

### DIFF
--- a/src/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/src/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -78,7 +78,7 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
         # theme locale
         if "theme" in config and "language" in config.get("theme"):
             custom_theme = config.get("theme")
-            theme_locale = custom_theme._vars.get("language")
+            theme_locale = custom_theme["language"] if Version(mkdocs_version) >= Version("1.6.0") else custom_theme._vars.get("language")
             logging.debug(
                 "Locale '%s' extracted from the custom theme: '%s'"
                 % (theme_locale, custom_theme.name)


### PR DESCRIPTION
Fixed another 'DeprecationWarning: Do not access Theme._vars, instead access the keys of Theme directly.' following #132

This PR will fixes this when get the 'language' key of theme.