### PR TITLE
Add datetime string to span element as title

### DIFF
--- a/src/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/src/mkdocs_git_revision_date_localized_plugin/util.py
@@ -186,9 +186,10 @@ class Util:
         """
         Wraps the date string in <span> elements with CSS identifiers.
         """
+        datetime_string = date_formats['datetime']
         for date_type, date_string in date_formats.items():
             date_formats[date_type] = (
-                '<span class="git-revision-date-localized-plugin git-revision-date-localized-plugin-%s">%s</span>'
-                % (date_type, date_string)
+                '<span class="git-revision-date-localized-plugin git-revision-date-localized-plugin-%s" title="%s">%s</span>'
+                % (date_type, datetime_string, date_string)
             )
         return date_formats


### PR DESCRIPTION
This is a simple solution to get the datetime on hover over the `<span>` element.

<img width="237" alt="image" src="https://github.com/user-attachments/assets/94caac6c-677b-4d98-8e18-7118366c6fb7">

## Alternative/additional solution

GitHub and GitLab include the timezone as well:

### GitHub

<img width="241" alt="image" src="https://github.com/user-attachments/assets/ab9230b8-ea88-44c7-b81e-6cdc2796559a">

### GitLab

<img width="233" alt="image" src="https://github.com/user-attachments/assets/93bf2648-f12e-4e58-b582-710aa2eb1ff9">

We could also consider having the title include the timezone (although I realized that depends on the presence of the `timezone` setting as well, otherwise it would be UTC) [side question here: would it be better to default to the system timezone here?]

Fixes #131