### PR TITLE
Add enabled on serve config option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -17,6 +17,7 @@ You can customize the plugin by setting options in `mkdocs.yml`. For example:
             - index.md
         enable_git_follow: true
         enabled: true
+        enabled_on_serve: true
         strict: true
         ignored_commits_file: .git-blame-ignore-revs
   ```
@@ -147,6 +148,10 @@ Which enables you to disable the plugin locally using:
 export ENABLED_GIT_REVISION_DATE=false
 mkdocs serve
 ```
+
+## `enabled_on_serve`
+
+Default is `true`. Allows you to deactivate this plugin when `mkdocs` is called with the command `serve`. A possible use case is local development where you might want faster build times and/or do not have git available.
 
 ## `strict`
 

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -69,6 +69,12 @@
                 "markdownDescription": "https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/options/#enabled",
                 "type": "boolean",
                 "default": true
+              },
+              "enabled_on_serve": {
+                "title": "Enable plugin when running `mkdocs serve`",
+                "markdownDescription": "https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/options/#enabled_on_serve",
+                "type": "boolean",
+                "default": true
               }
             },
             "additionalProperties": false,


### PR DESCRIPTION
Provide an option like that in [mkdocs-git-authors-plugin](https://timvink.github.io/mkdocs-git-authors-plugin/options.html#:~:text=enabled_on_serve%3A%20true), with which the plugin can be disabled when running with `mkdocs serve`, for faster build times and hot reloading when running locally (especially with big projects). This can be more convenient than setting env vars.