### PR TITLE
fix: Correct typo in warning suggesting "enable_git_follow: false"

### DIFF
--- a/src/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/src/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -342,7 +342,7 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
         if first_revision_timestamp > last_revision_timestamp:
             # See also https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/issues/111
             msg = "First revision timestamp is older than last revision timestamp for page %s. " % page.file.src_path
-            msg += "This can be due to a quick in `git` follow behaviour. You can try to set `enable_git_follow: false` in the plugin configuration."
+            msg += "This can be due to a quirk in `git` follow behaviour. You can try to set `enable_git_follow: false` in the plugin configuration."
             logging.warning(msg)
             first_revision_hash, first_revision_timestamp = last_revision_hash, last_revision_timestamp
 


### PR DESCRIPTION
In the warning introduced in 596273fd8db1d7c51a851a9ec204db3a13a1ead6,
the word "quirk" is confusingly rendered as "quick". Fix the warning
to correctly say "quirk".
