### PR TITLE
feat: support monorepo/techdocs when getting last site revision info

### DIFF
--- a/src/mkdocs_git_revision_date_localized_plugin/plugin.py
+++ b/src/mkdocs_git_revision_date_localized_plugin/plugin.py
@@ -84,9 +84,16 @@ class GitRevisionDateLocalizedPlugin(BasePlugin):
         )
 
         # Save last commit timestamp for entire site
-        self.last_site_revision_hash, self.last_site_revision_timestamp = self.util.get_git_commit_timestamp(
-            config.get("docs_dir")
-        )
+        # Support monorepo/techdocs, which copies the docs_dir to a temporary directory
+        mono_repo_plugin = config.get("plugins", {}).get("monorepo", None)
+        if mono_repo_plugin is not None and hasattr(mono_repo_plugin, "originalDocsDir") and mono_repo_plugin.originalDocsDir is not None:
+            self.last_site_revision_hash, self.last_site_revision_timestamp = self.util.get_git_commit_timestamp(
+                mono_repo_plugin.originalDocsDir
+            )
+        else:
+            self.last_site_revision_hash, self.last_site_revision_timestamp = self.util.get_git_commit_timestamp(
+                config.get("docs_dir")
+            )
 
         # Get locale from plugin configuration
         plugin_locale = self.config.get("locale", None)


### PR DESCRIPTION
Hi 👋

This PR allows to correctly compute the last site revision infos (ie, `git_site_revision_date_localized_*`) when using the monorepo/techdocs plugin.

When using the monorepo plugin, docs are merged in a temporary directory and `docs_dir` is changed to that directory, without Git infos and without the fallback to build date, builds fail.

This fix is similar to what's done in the `on_files` handler.