### PR TITLE
Fix tests for click >= 8.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ fix = true
 
 [tool.uv]
 dev-dependencies = [
-    "click>=8.1.8,<8.2.0",
+    "click>=8.1.8",
     "codecov>=2.1.13",
     "mkdocs-gen-files>=0.5.0",
     "mkdocs-git-authors-plugin>=0.9.2",

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -538,7 +538,7 @@ def test_type_unknown(mkdocs_file, error, tmp_path):
     result = build_docs_setup(testproject_path)
     assert result.exit_code == 1
 
-    assert error in result.stdout or error in str(result.exc_info[0])
+    assert error in result.output or error in str(result.exc_info[0])
 
 
 def test_exclude_pages(tmp_path):


### PR DESCRIPTION
Update the tests for click >= 8.2.0, by checking the combined "output" attribute for the error message.  With click >= 8.2.0, errors are emitted to stderr rather than stdout -- checking the combined output achieves compatibility with both version ranges.

Fixes #186