### PR TITLE
fix: add missing follow param to util

### DIFF
--- a/src/mkdocs_git_revision_date_localized_plugin/util.py
+++ b/src/mkdocs_git_revision_date_localized_plugin/util.py
@@ -118,6 +118,7 @@ class Util:
                     format="%H %at",
                     n=len(self.ignored_commits) + 1,
                     no_show_signature=True,
+                    follow=follow_option,
                 ).split("\n")
 
                 # process the commits for the file in reverse-chronological order. Ignore any commit that is on the


### PR DESCRIPTION
When getting the latest commit hash in `util.py:Util.get_git_commit_timestamp`, the `follow_option` var is not passed to `git.log`, causing the `enable_git_follow` config not working on latest commit.

(When move a page to a new place, and then ignore the commit of this movement, the old commit is not loaded, and the latest commit is forcedly set to be the commit which should be ignored due to this bug.)