### PR TITLE
Fix paths in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include mkdocs_git_revision_date_localized_plugin/js/*.js
-include mkdocs_git_revision_date_localized_plugin/css/*.css
+include src/mkdocs_git_revision_date_localized_plugin/js/*.js
+include src/mkdocs_git_revision_date_localized_plugin/css/*.css


### PR DESCRIPTION
According to [setuptools documentation][1],
> Directory patterns are relative to the root of the project directory.

This makes sure that the JS and CSS files are really installed when building this project out of git tree (e.g. when packaging), and fixes these warnings:

    warning: no files found matching 'mkdocs_git_revision_date_localized_plugin/js/*.js'
    warning: no files found matching 'mkdocs_git_revision_date_localized_plugin/css/*.css'

[1]: https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html