### PR TITLE
ci: update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,7 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v8
+              uses: astral-sh/setup-uv@v7
               with:
                   version: latest
                   enable-cache: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,7 @@ jobs:
             - uses: actions/checkout@v6
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v6
+              uses: astral-sh/setup-uv@v8
               with:
                   version: latest
                   enable-cache: true

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
 
     - name: Make sure unit tests succeed
       run: |

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -14,15 +14,15 @@ jobs:
       id-token: write
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: '0'
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
 
     - name: Make sure unit tests succeed
       run: |

--- a/.github/workflows/scheduled_unittests.yml
+++ b/.github/workflows/scheduled_unittests.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
     - name: Run unit tests
       run: |
         git config --global user.name "Github Action"

--- a/.github/workflows/scheduled_unittests.yml
+++ b/.github/workflows/scheduled_unittests.yml
@@ -15,9 +15,9 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
     - name: Run unit tests
       run: |
         git config --global user.name "Github Action"

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,10 +11,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
 
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unittests_codecov.yml
+++ b/.github/workflows/unittests_codecov.yml
@@ -19,10 +19,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
 
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@v8
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -34,7 +34,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: "contains(env.USING_COVERAGE, matrix.python-version)"
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       with:
         files: ./coverage.xml
         flags: unittests

--- a/.github/workflows/unittests_codecov.yml
+++ b/.github/workflows/unittests_codecov.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Why

GitHub Actions is removing the Node.js 20 runtime — actions are **forced to Node 24 on 2026-06-16** and Node 20 is **removed on 2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Our workflows emitted:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5 …

## Changes

Bump the actions that still ran on Node 20 to their current Node 24 majors:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` / `@master` | `@v6` |
| `actions/setup-python` | `@v5` | `@v6` |
| `codecov/codecov-action` | `@v4` | `@v6` |

While touching these files:
- Pinned the fragile `actions/checkout@master` refs (used in the unit-test workflows) to `@v6` — tracking `master` of a third-party action is unpredictable.
- Aligned the mixed `astral-sh/setup-uv` versions (`@v6`/`@v7`) to `@v7`. (`setup-uv` is not Node-20-flagged; v7 is the latest *floating major* tag — v8 only publishes full version tags like `v8.1.0`, no `@v8` major, so it can't be pinned the same way.)

`pypa/gh-action-pypi-publish@release/v1` is the maintainer-recommended pin and already runs on Node 24, so it's left unchanged.

No source or test code changes. CI on this PR exercises the updated checkout/setup-uv/codecov actions directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)