### PR TITLE
deps: bump idna and pymdown-extensions to patch Dependabot security alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,13 @@ dev = [
     "prek>=0.3.0",
 ]
 
+[tool.uv]
+# mkdocs-techdocs-core hard-pins pymdown-extensions==10.21.2, which is affected
+# by a path-traversal vulnerability in pymdownx.snippets. Override to the
+# patched 10.21.3 (an API-compatible patch release) so the dev/CI environment
+# is not resolved to the vulnerable version.
+override-dependencies = ["pymdown-extensions>=10.21.3"]
+
 [tool.ty.environment]
 python-version = "3.10"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[manifest]
+overrides = [{ name = "pymdown-extensions", specifier = ">=10.21.3" }]
+
 [[package]]
 name = "babel"
 version = "2.17.0"
@@ -347,11 +350,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -851,15 +854,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves the two open Dependabot security alerts (both in the dev/CI dependency tree — the plugin's runtime deps are unaffected):

| Package | From | To | Severity | Issue |
|---|---|---|---|---|
| `idna` | 3.11 | 3.18 | medium | `idna.encode()` inputs can bypass the CVE-2024-3651 fix |
| `pymdown-extensions` | 10.21.2 | 10.21.3 | medium | `pymdownx.snippets` sibling-prefix path traversal bypass of `restrict_base_path` |

## Note on pymdown-extensions

`mkdocs-techdocs-core` hard-pins `pymdown-extensions==10.21.2` (even in its latest release, 1.6.2), which is why a plain `uv lock --upgrade` couldn't move it. Since techdocs-core is used by the test suite (`tests/fixtures/techdocs-core/`), it can't be dropped. Instead this adds a `[tool.uv] override-dependencies` entry forcing the API-compatible patch release `10.21.3`.

## Verification

- `uv lock` / `uv sync` resolve cleanly (65 packages)
- Full test suite passes locally: **38 passed, 6 skipped**, including the techdocs-core build test that exercises pymdownx

🤖 Generated with [Claude Code](https://claude.com/claude-code)